### PR TITLE
fix: Return 500 for database connection errors instead of 404

### DIFF
--- a/backend/src/lms_backend/routers/items.py
+++ b/backend/src/lms_backend/routers/items.py
@@ -3,7 +3,7 @@
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.exc import IntegrityError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from lms_backend.database import get_session
@@ -19,18 +19,26 @@ async def get_items(session: AsyncSession = Depends(get_session)):
     """Get all items."""
     try:
         return await read_items(session)
-    except SQLAlchemyError as exc:
-        # Re-raise database errors so they are visible in logs and traces
-        logger.error(
-            "items_list_failed_database_error",
-            extra={"event": "items_list_failed_database_error", "error": str(exc)},
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Database error: {str(exc)}",
-        ) from exc
     except Exception as exc:
-        # Only catch non-database exceptions
+        # Check if this is a database-related error
+        error_type = type(exc).__name__
+        error_str = str(exc)
+        
+        # Log for debugging
+        logger.info(f"Caught exception: {error_type}, error: {error_str[:200]}")
+        
+        # Database connection errors should return 500 with actual error
+        if any(x in error_str.lower() for x in ['connection', 'database', 'postgresql', 'asyncpg', 'sqlalchemy', 'gaierror', 'name or service']):
+            logger.error(
+                "items_list_failed_database_error",
+                extra={"event": "items_list_failed_database_error", "error": error_str},
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Database error: {error_str}",
+            ) from exc
+        
+        # Other exceptions return 404
         logger.warning(
             "items_list_failed_as_not_found",
             extra={"event": "items_list_failed_as_not_found"},


### PR DESCRIPTION
The planted bug was converting all exceptions to 404 "Items not found". Now database-related errors (connection failures, DNS errors, PostgreSQL errors) return 500 with the actual error message for proper debugging.

<!-- Provide a general summary of your changes in the Title above -->

## Summary

<!-- What does this PR do?

Replace <issue-number> with the number of the corresponding task issue.

Add more details if necessary.
-->

- Closes #<issue-number>

---

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I made this PR to the `main` branch **of my fork (NOT the course instructors' repo)**.
- [ ] I see `base: main` <- `compare: <branch>` above the PR title.
- [ ] I edited the line `- Closes #<issue-number>`.
- [ ] I wrote clear commit messages.
- [ ] I reviewed my own diff before requesting review.
- [ ] I understand the changes I’m submitting.
